### PR TITLE
update to use standard gold kc roles

### DIFF
--- a/backend/src/main/groovy/bc/gov/agri/config/SecurityConfig.java
+++ b/backend/src/main/groovy/bc/gov/agri/config/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
   private JwtAuthenticationConverter jwtAuthenticationConverter() {
     JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter =
         new JwtGrantedAuthoritiesConverter();
-    jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName("roles");
+    jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName("client_roles");
     jwtGrantedAuthoritiesConverter.setAuthorityPrefix("ROLE_");
     JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
     jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(jwtGrantedAuthoritiesConverter);

--- a/frontend/src/admin/auth.js
+++ b/frontend/src/admin/auth.js
@@ -12,9 +12,14 @@ const AuthRequired = (props) => {
 
   const [keycloakInstance] = useState(Keycloak(
     {
-      clientId: CONFIG.KEYCLOAK_CLIENT_ID,
-      realm: CONFIG.KEYCLOAK_REALM,
       url: CONFIG.KEYCLOAK_URL,
+      realm: CONFIG.KEYCLOAK_REALM,
+      sslRequired: "external",
+      resource: CONFIG.KEYCLOAK_CLIENT_ID,
+      publicClient: true,
+      confidentialPort: 0,
+      realmPublicKey: CONFIG.KEYCLOAK_PUBLIC_KEY,
+      clientId: CONFIG.KEYCLOAK_CLIENT_ID,
     },
   ));
 
@@ -23,6 +28,7 @@ const AuthRequired = (props) => {
       {
         checkLoginIframe: false,
         onLoad: 'check-sso',
+        pkceMethod: 'S256'
       },
     ).then((auth) => {
       setAuthenticated(auth);


### PR DESCRIPTION
* Update keycloak-js init to use pkceMethod
  * This is a security requirement for Public clients accessing Keycloak Gold
* Update Java security config to look for "client_roles" instead of "roles" to accommodate updated JWT in Gold.