### PR TITLE
Nmp psql image update

### DIFF
--- a/openshift/templates/postgres-crunchy.yaml
+++ b/openshift/templates/postgres-crunchy.yaml
@@ -101,7 +101,7 @@ objects:
                 claimName: nmp-msa-postgresql
           containers:
             - name: postgresql
-              image: 'image-registry.apps.silver.devops.gov.bc.ca/624dc1-tools/psql-crunchy'
+              image: 'image-registry.apps.silver.devops.gov.bc.ca/624dc1-tools/psql-crunchy:prod'
               ports:
                 - containerPort: 5432
                   protocol: TCP

--- a/openshift/templates/postgres-crunchy.yaml
+++ b/openshift/templates/postgres-crunchy.yaml
@@ -101,7 +101,7 @@ objects:
                 claimName: nmp-msa-postgresql
           containers:
             - name: postgresql
-              image: 'crunchydata/crunchy-postgres-gis:centos7-12.4-3.0-4.4.1'
+              image: 'image-registry.apps.silver.devops.gov.bc.ca/624dc1-tools/psql-crunchy'
               ports:
                 - containerPort: 5432
                   protocol: TCP


### PR DESCRIPTION
* The old Postgres image was looking at a generic image through Crunchy Data, which is no longer available.
* This update aligns with what's in prod now using a bcgov public image.
* The change was tested to prove that it properly builds the psql pod in dev when updated and reloaded.